### PR TITLE
Add OpenTTD admin helper bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.sqlite3
+.eggs/
+*.egg-info/
+.pytest_cache/
+.env
+.venv

--- a/README.md
+++ b/README.md
@@ -1,0 +1,117 @@
+# OpenTTD Server Helper Bot
+
+Ein Python-Bot, der über den Admin-Port eines OpenTTD-Servers läuft und dabei hilft, Serverregeln zu verteilen, Firmenpasswörter sicher zu verwalten und administrative Aufgaben (z. B. Firmen zurücksetzen) über Chatbefehle zu automatisieren.
+
+## Features
+
+- Reagiert auf Befehle `!help`, `!rules`, `!pw`, `!reset` und `!confirm` sowohl im öffentlichen Chat als auch per Flüstern.
+- Erzwingt, dass Passwörter ausschließlich per `/server` (privat) übermittelt werden.
+- Speichert Firmenpasswörter persistent und setzt sie nach einem Serverneustart automatisch wieder.
+- Schickt neuen Spielern automatisch eine Begrüßung sowie Hilfe- und Regelhinweise.
+- Informiert neue Firmeninhaber direkt darüber, wie ein Passwort gesetzt wird.
+- Stellt sicher, dass `!reset` nur die Firma des aufrufenden Spielers betrifft und mit `!confirm` abgesichert wird.
+
+## Installation
+
+1. Abhängigkeiten installieren (Python ≥ 3.11 wird empfohlen):
+
+   ```bash
+   python -m pip install -r <(printf 'pyOpenTTDAdmin>=1.0.2\n')
+   ```
+
+2. Umgebungsvariablen setzen (siehe Tabelle unten) und anschließend den Bot starten:
+
+   ```bash
+   export OTTD_HOST=openttd2
+   export OTTD_ADMIN_PORT=3977
+   export OTTD_ADMIN_PASSWORD=meinadminpasswort
+   export BOT_NAME=ServerBot
+   export COMMAND_PREFIX=!
+   export STATE_FILE=/data/state.json
+   export MESSAGES_FILE=/config/messages.json
+   python bot.py
+   ```
+
+### Konfiguration per Umgebung
+
+| Variable                         | Beschreibung                                                                 | Standard |
+|----------------------------------|------------------------------------------------------------------------------|----------|
+| `OTTD_HOST`                      | Hostname oder IP des OpenTTD-Servers                                         | `127.0.0.1` |
+| `OTTD_ADMIN_PORT`                | Admin-Port des Servers                                                       | `3977` |
+| `OTTD_ADMIN_PASSWORD`            | Admin-Passwort des Servers (Pflicht)                                         | – |
+| `BOT_NAME`                       | Name des Bots (erscheint im Chat)                                            | `ServerBot` |
+| `COMMAND_PREFIX`                 | Präfix für Chatbefehle                                                       | `!` |
+| `STATE_FILE`                     | Speicherort für die persistenten Passwörter                                 | `./state.json` |
+| `MESSAGES_FILE`                  | Pfad zur JSON-Datei mit Nachrichtentexten                                    | `./messages.json` |
+| `STARTUP_REAPPLY_DELAY_SECONDS`  | Verzögerung, bevor gespeicherte Passwörter nach dem Start neu gesetzt werden | `5` |
+| `RECONNECT_DELAY_SECONDS`        | Wartezeit nach einem Fehler, bevor ein Reconnect versucht wird              | `5` |
+
+Die Datei `messages.json` kann nach eigenen Wünschen angepasst werden (Texte, Sprache, zusätzliche Hinweise). Platzhalter wie `{client_name}`, `{bot_name}` oder `{company_name}` werden automatisch ersetzt.
+
+## Docker-/Portainer-Integration
+
+Der Bot wurde so aufgebaut, dass er im gleichen Docker-Netzwerk wie der OpenTTD-Server laufen kann. Ein Beispiel-Stack für Portainer könnte wie folgt aussehen:
+
+```yaml
+version: "3.8"
+
+services:
+  openttd:
+    image: ghcr.io/ropenttd/openttd:latest
+    container_name: openttd
+    restart: unless-stopped
+    environment:
+      - TZ=Europe/Berlin
+      - loadgame=last-autosave
+    ports:
+      - "3979:3979/tcp"
+      - "3979:3979/udp"
+    volumes:
+      - /srv/docker/openttd/server:/config
+    networks: [games]
+
+  ottd-bot:
+    image: python:3.11-slim
+    container_name: ottd-bot
+    restart: unless-stopped
+    environment:
+      - TZ=Europe/Berlin
+      - PYTHONUNBUFFERED=1
+      - OTTD_HOST=openttd
+      - OTTD_ADMIN_PORT=3977
+      - OTTD_ADMIN_PASSWORD=topsecret
+      - BOT_NAME=ServerBot
+      - COMMAND_PREFIX=!
+      - STATE_FILE=/data/state.json
+      - MESSAGES_FILE=/config/messages.json
+      - STARTUP_REAPPLY_DELAY_SECONDS=5
+    volumes:
+      - /srv/docker/openttd/bot/data:/data
+      - /srv/docker/openttd/bot/messages.json:/config/messages.json:ro
+      - /srv/docker/openttd/bot/bot.py:/app/bot.py:ro
+    working_dir: /app
+    command: >
+      sh -c "pip install --no-cache-dir pyOpenTTDAdmin && python -u /app/bot.py"
+    depends_on:
+      - openttd
+    networks: [games]
+
+networks:
+  games:
+    driver: bridge
+```
+
+Die Datei `messages.json` aus diesem Repository kann als Vorlage verwendet und an die eigenen Bedürfnisse angepasst werden. Passwörter werden im Volume `/srv/docker/openttd/bot/data` gespeichert, sodass sie Container-Neustarts überstehen.
+
+## Tests
+
+Zum Ausführen der Tests:
+
+```bash
+python -m pip install pytest
+python -m pytest
+```
+
+## Lizenz
+
+Veröffentlicht unter der MIT-Lizenz (siehe `LICENSE`).

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,34 @@
+"""Entry point for running the OpenTTD helper bot."""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from openttd_bot.config import BotConfig
+from openttd_bot.messages import MessageCatalog
+from openttd_bot.runner import BotRunner
+from openttd_bot.state import StateStore
+
+
+def configure_logging() -> None:
+    level_name = "INFO"
+    logging.basicConfig(
+        level=getattr(logging, level_name, logging.INFO),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+
+def main() -> int:
+    configure_logging()
+    config = BotConfig.from_env()
+    messages = MessageCatalog.load(config.messages_file)
+    state_store = StateStore(config.state_file)
+
+    runner = BotRunner(config, messages, state_store)
+    runner.run()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/messages.json
+++ b/messages.json
@@ -1,0 +1,33 @@
+{
+  "welcome": [
+    "Willkommen {client_name}!",
+    "Dieser Server wird von {bot_name} betreut."
+  ],
+  "help": [
+    "Verfügbare Befehle: !help, !rules, !pw <passwort>, !reset, !confirm.",
+    "Sende Befehle an den Server mit /server <text>."
+  ],
+  "rules": [
+    "1. Respektiere andere Spieler.",
+    "2. Blockiere keine Strecken."
+  ],
+  "password_instructions": [
+    "Sichere deine Firma mit /server !pw <passwort>.",
+    "Das Passwort wird automatisch nach Serverneustarts wieder gesetzt."
+  ],
+  "password_whisper_only": "Bitte sende !pw per /server, damit dein Passwort geheim bleibt.",
+  "password_missing_argument": "Bitte gib ein Passwort an: !pw <passwort> oder !pw clear.",
+  "password_invalid": "Ungültiges Passwort.",
+  "password_set_success": "Passwort für Firma {company_name} wurde gespeichert.",
+  "password_clear_success": "Passwort für Firma {company_name} wurde entfernt.",
+  "password_not_in_company": "Du musst einer Firma angehören um ein Passwort zu setzen.",
+  "reset_not_in_company": "Du befindest dich aktuell in keiner Firma.",
+  "reset_prompt": [
+    "Du möchtest Firma {company_name} zurücksetzen.",
+    "Sende !confirm um dies zu bestätigen."
+  ],
+  "reset_confirmed": "Firma {company_name} wurde zurückgesetzt.",
+  "reset_no_pending": "Es liegt keine offene Zurücksetzung vor.",
+  "reset_wrong_company": "Du befindest dich nicht mehr in Firma {company_name}. Reset abgebrochen.",
+  "company_password_reapplied": "Das gespeicherte Passwort für Firma {company_name} wurde erneut gesetzt."
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "openttd-bot"
+version = "0.1.0"
+description = "Helper bot for OpenTTD dedicated servers"
+readme = "README.md"
+authors = [{ name = "JobbeDeluxe" }]
+license = { file = "LICENSE" }
+requires-python = ">=3.11"
+dependencies = [
+    "pyOpenTTDAdmin>=1.0.2",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
+
+[build-system]
+requires = ["setuptools>=65", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+addopts = "-ra"

--- a/src/openttd_bot/__init__.py
+++ b/src/openttd_bot/__init__.py
@@ -1,0 +1,5 @@
+"""High level package for the OpenTTD server helper bot."""
+
+from .config import BotConfig  # noqa: F401
+
+__all__ = ["BotConfig"]

--- a/src/openttd_bot/config.py
+++ b/src/openttd_bot/config.py
@@ -1,0 +1,51 @@
+"""Configuration helpers for the OpenTTD helper bot."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+
+
+@dataclass(slots=True)
+class BotConfig:
+    """Runtime configuration for the bot."""
+
+    host: str
+    admin_port: int
+    admin_password: str
+    bot_name: str
+    command_prefix: str
+    state_file: Path
+    messages_file: Path
+    startup_reapply_delay_seconds: int
+    reconnect_delay_seconds: int = 5
+
+    @classmethod
+    def from_env(cls) -> "BotConfig":
+        """Create a configuration object from environment variables."""
+
+        host = os.getenv("OTTD_HOST", "127.0.0.1")
+        port = int(os.getenv("OTTD_ADMIN_PORT", "3977"))
+        admin_password = os.getenv("OTTD_ADMIN_PASSWORD", "")
+        if not admin_password:
+            raise ValueError("Environment variable OTTD_ADMIN_PASSWORD must be set")
+
+        bot_name = os.getenv("BOT_NAME", "ServerBot")
+        command_prefix = os.getenv("COMMAND_PREFIX", "!")
+        state_file = Path(os.getenv("STATE_FILE", "state.json")).expanduser().resolve()
+        messages_file = Path(os.getenv("MESSAGES_FILE", "messages.json")).expanduser().resolve()
+        startup_delay = int(os.getenv("STARTUP_REAPPLY_DELAY_SECONDS", "5"))
+        reconnect_delay = int(os.getenv("RECONNECT_DELAY_SECONDS", "5"))
+
+        return cls(
+            host=host,
+            admin_port=port,
+            admin_password=admin_password,
+            bot_name=bot_name,
+            command_prefix=command_prefix,
+            state_file=state_file,
+            messages_file=messages_file,
+            startup_reapply_delay_seconds=startup_delay,
+            reconnect_delay_seconds=reconnect_delay,
+        )

--- a/src/openttd_bot/core.py
+++ b/src/openttd_bot/core.py
@@ -1,0 +1,358 @@
+"""Core bot logic for handling events and commands."""
+
+from __future__ import annotations
+
+import logging
+import time
+from types import SimpleNamespace
+from typing import Dict, Optional
+
+from pyopenttdadmin.enums import Actions, ChatDestTypes
+
+from .config import BotConfig
+from .messages import MessageCatalog
+from .messenger import AdminMessenger
+from .models import ClientState, CompanyState, SPECTATOR_COMPANY_ID
+from .state import StateStore
+
+LOGGER = logging.getLogger(__name__)
+
+
+class BotCore:
+    """Encapsulates all stateful behaviour of the bot."""
+
+    def __init__(
+        self,
+        config: BotConfig,
+        messages: MessageCatalog,
+        state_store: StateStore,
+        messenger: AdminMessenger,
+    ) -> None:
+        self.config = config
+        self.messages = messages
+        self.state_store = state_store
+        self.messenger = messenger
+        self.clients: Dict[int, ClientState] = {}
+        self.companies: Dict[int, CompanyState] = {}
+        self.pending_resets: Dict[int, int] = {}
+        self.server_name: Optional[str] = None
+        self._welcome_sent: set[int] = set()
+        self._last_password_application: Dict[int, float] = {}
+
+    # ------------------------------------------------------------------
+    # Event handling helpers
+    # ------------------------------------------------------------------
+
+    def on_welcome(self, packet: SimpleNamespace) -> None:
+        """Remember server level metadata."""
+
+        self.server_name = getattr(packet, "server_name", None)
+        LOGGER.info("Connected to server: %s", self.server_name)
+
+    def on_client_join(self, packet: SimpleNamespace) -> None:
+        client_id = getattr(packet, "id", None)
+        if client_id is None:
+            return
+        LOGGER.info("Client %s joined", client_id)
+
+    def on_client_quit(self, packet: SimpleNamespace) -> None:
+        client_id = getattr(packet, "id", None)
+        if client_id is None:
+            return
+        LOGGER.info("Client %s left", client_id)
+        self.clients.pop(client_id, None)
+        self.pending_resets.pop(client_id, None)
+        self._welcome_sent.discard(client_id)
+
+    def on_client_info(self, packet: SimpleNamespace) -> None:
+        client_id = getattr(packet, "id", None)
+        if client_id is None:
+            return
+
+        client = self.clients.get(client_id)
+        if client is None:
+            client = ClientState(client_id=client_id)
+            self.clients[client_id] = client
+
+        client.name = getattr(packet, "name", client.name)
+        company_id = self._normalise_company_id(getattr(packet, "company_id", None))
+        client.company_id = company_id
+
+        if client_id not in self._welcome_sent:
+            self._welcome_sent.add(client_id)
+            self._send_join_messages(client)
+
+    def on_client_update(self, packet: SimpleNamespace) -> None:
+        client_id = getattr(packet, "id", None)
+        if client_id is None:
+            return
+        client = self.clients.setdefault(client_id, ClientState(client_id=client_id))
+        client.name = getattr(packet, "name", client.name)
+        previous_company = client.company_id
+        company_id = self._normalise_company_id(getattr(packet, "company_id", None))
+        client.company_id = company_id
+
+        if previous_company != company_id and company_id is not None:
+            LOGGER.info("Client %s joined company %s", client_id, company_id)
+            self._send_password_instructions(client)
+
+    def on_company_info(self, packet: SimpleNamespace) -> None:
+        company_id = getattr(packet, "id", None)
+        if company_id is None:
+            return
+        company = self.companies.get(company_id)
+        if company is None:
+            company = CompanyState(company_id=company_id)
+            self.companies[company_id] = company
+
+        company.name = getattr(packet, "name", company.name or f"Firma #{company_id}")
+        company.manager_name = getattr(packet, "manager_name", company.manager_name)
+        passworded = bool(getattr(packet, "passworded", company.passworded))
+        company.update_passworded(passworded)
+
+        if not passworded:
+            self._maybe_reapply_password(company_id, reason="company_info")
+
+    def on_company_update(self, packet: SimpleNamespace) -> None:
+        company_id = getattr(packet, "id", None)
+        if company_id is None:
+            return
+        company = self.companies.setdefault(company_id, CompanyState(company_id=company_id))
+        company.name = getattr(packet, "name", company.name)
+        passworded = bool(getattr(packet, "passworded", company.passworded))
+        company.update_passworded(passworded)
+        if not passworded:
+            self._maybe_reapply_password(company_id, reason="company_update")
+
+    def on_company_remove(self, packet: SimpleNamespace) -> None:
+        company_id = getattr(packet, "id", None)
+        if company_id is None:
+            return
+        LOGGER.info("Company %s removed", company_id)
+        self.companies.pop(company_id, None)
+        self.state_store.clear_company_password(company_id)
+        self._last_password_application.pop(company_id, None)
+
+    # ------------------------------------------------------------------
+    # Chat handling
+    # ------------------------------------------------------------------
+
+    def on_chat(self, packet: SimpleNamespace) -> None:
+        action = getattr(packet, "action", None)
+        desttype = getattr(packet, "desttype", None)
+        if action not in {Actions.CHAT, Actions.CHAT_CLIENT, Actions.CHAT_COMPANY}:
+            return
+        if desttype not in {ChatDestTypes.BROADCAST, ChatDestTypes.CLIENT, ChatDestTypes.TEAM}:
+            return
+
+        raw_message = getattr(packet, "message", "")
+        message = raw_message.strip()
+        if not message.startswith(self.config.command_prefix):
+            return
+
+        client_id = getattr(packet, "id", None)
+        if client_id is None:
+            return
+        client = self.clients.get(client_id)
+        if client is None:
+            LOGGER.debug("Ignoring command from unknown client %s", client_id)
+            return
+
+        command_line = message[len(self.config.command_prefix) :].strip()
+        if not command_line:
+            return
+
+        parts = command_line.split(maxsplit=1)
+        command = parts[0].lower()
+        argument = parts[1].strip() if len(parts) > 1 else ""
+        is_private = desttype == ChatDestTypes.CLIENT
+
+        if command == "help":
+            self._send_help(client)
+        elif command == "rules":
+            self._send_rules(client)
+        elif command == "pw":
+            self._handle_password_command(client, argument, is_private)
+        elif command == "reset":
+            self._handle_reset_command(client)
+        elif command == "confirm":
+            self._handle_confirm_command(client)
+        else:
+            LOGGER.debug("Unknown command %s from client %s", command, client_id)
+
+    # ------------------------------------------------------------------
+    # Command implementations
+    # ------------------------------------------------------------------
+
+    def _send_help(self, client: ClientState) -> None:
+        lines = self.messages.get_lines("help", client_name=client.name, bot_name=self.config.bot_name)
+        if lines:
+            self.messenger.send_private_lines(client.client_id, lines)
+
+    def _send_rules(self, client: ClientState) -> None:
+        lines = self.messages.get_lines("rules", client_name=client.name, bot_name=self.config.bot_name)
+        if lines:
+            self.messenger.send_private_lines(client.client_id, lines)
+
+    def _send_join_messages(self, client: ClientState) -> None:
+        context = {
+            "client_name": client.name or f"Spieler {client.client_id}",
+            "bot_name": self.config.bot_name,
+            "server_name": self.server_name or "OpenTTD",
+        }
+        for key in ("welcome", "help", "rules"):
+            lines = self.messages.get_lines(key, **context)
+            if lines:
+                self.messenger.send_private_lines(client.client_id, lines)
+
+    def _send_password_instructions(self, client: ClientState) -> None:
+        company = self.companies.get(client.company_id or -1)
+        context = {
+            "client_name": client.name,
+            "bot_name": self.config.bot_name,
+            "company_name": company.name if company else f"Firma #{client.company_id}",
+        }
+        lines = self.messages.get_lines("password_instructions", **context)
+        if lines:
+            self.messenger.send_private_lines(client.client_id, lines)
+
+    def _handle_password_command(self, client: ClientState, argument: str, is_private: bool) -> None:
+        if not is_private:
+            message = self.messages.get_message("password_whisper_only")
+            if message:
+                self.messenger.send_private(client.client_id, message)
+            return
+
+        if client.is_spectator or client.company_id is None:
+            message = self.messages.get_message("password_not_in_company")
+            if message:
+                self.messenger.send_private(client.client_id, message)
+            return
+
+        if not argument:
+            message = self.messages.get_message("password_missing_argument")
+            if message:
+                self.messenger.send_private(client.client_id, message)
+            return
+
+        company_id = client.company_id
+        company = self.companies.get(company_id)
+        company_name = company.name if company else f"Firma #{company_id}"
+
+        lowered = argument.lower()
+        if lowered in {"clear", "reset", "remove", "delete", "none", "leer"}:
+            self.messenger.clear_company_password(company_id)
+            self.state_store.clear_company_password(company_id)
+            self._last_password_application.pop(company_id, None)
+            message = self.messages.get_message("password_clear_success", company_name=company_name)
+            if message:
+                self.messenger.send_private(client.client_id, message)
+            return
+
+        if any(ch in argument for ch in {"\n", "\r"}):
+            message = self.messages.get_message("password_invalid")
+            if message:
+                self.messenger.send_private(client.client_id, message)
+            return
+
+        self.state_store.set_company_password(company_id, argument)
+        self._apply_company_password(company_id, argument, notify=False)
+        message = self.messages.get_message("password_set_success", company_name=company_name)
+        if message:
+            self.messenger.send_private(client.client_id, message)
+
+    def _handle_reset_command(self, client: ClientState) -> None:
+        if client.company_id is None:
+            message = self.messages.get_message("reset_not_in_company")
+            if message:
+                self.messenger.send_private(client.client_id, message)
+            return
+
+        self.pending_resets[client.client_id] = client.company_id
+        company = self.companies.get(client.company_id)
+        company_name = company.name if company else f"Firma #{client.company_id}"
+        lines = self.messages.get_lines("reset_prompt", company_name=company_name)
+        if lines:
+            self.messenger.send_private_lines(client.client_id, lines)
+
+    def _handle_confirm_command(self, client: ClientState) -> None:
+        pending_company = self.pending_resets.get(client.client_id)
+        if pending_company is None:
+            message = self.messages.get_message("reset_no_pending")
+            if message:
+                self.messenger.send_private(client.client_id, message)
+            return
+
+        if client.company_id != pending_company:
+            company = self.companies.get(pending_company)
+            company_name = company.name if company else f"Firma #{pending_company}"
+            message = self.messages.get_message("reset_wrong_company", company_name=company_name)
+            if message:
+                self.messenger.send_private(client.client_id, message)
+            self.pending_resets.pop(client.client_id, None)
+            return
+
+        self.pending_resets.pop(client.client_id, None)
+        self.messenger.reset_company(pending_company)
+        company = self.companies.get(pending_company)
+        company_name = company.name if company else f"Firma #{pending_company}"
+        message = self.messages.get_message("reset_confirmed", company_name=company_name)
+        if message:
+            self.messenger.send_private(client.client_id, message)
+
+    # ------------------------------------------------------------------
+    # Password helpers
+    # ------------------------------------------------------------------
+
+    def _apply_company_password(self, company_id: int, password: str, notify: bool) -> None:
+        now = time.monotonic()
+        self._last_password_application[company_id] = now
+        try:
+            self.messenger.set_company_password(company_id, password)
+        finally:
+            company = self.companies.get(company_id)
+            if company is not None:
+                company.passworded = True
+        if notify:
+            self._notify_company_members(company_id, "company_password_reapplied")
+
+    def _maybe_reapply_password(self, company_id: int, reason: str) -> None:
+        password = self.state_store.get_company_password(company_id)
+        if not password:
+            return
+        last = self._last_password_application.get(company_id)
+        now = time.monotonic()
+        if last is not None and now - last < 2.0:
+            LOGGER.debug("Skip password reapply for company %s due to cooldown", company_id)
+            return
+        LOGGER.info("Re-applying password for company %s (reason: %s)", company_id, reason)
+        self._apply_company_password(company_id, password, notify=True)
+
+    def _notify_company_members(self, company_id: int, message_key: str) -> None:
+        company = self.companies.get(company_id)
+        company_name = company.name if company else f"Firma #{company_id}"
+        lines = self.messages.get_lines(message_key, company_name=company_name)
+        if not lines:
+            return
+        for client in self.clients.values():
+            if client.company_id == company_id:
+                self.messenger.send_private_lines(client.client_id, lines)
+
+    def reapply_stored_passwords(self) -> None:
+        """Reapply all stored passwords via RCON."""
+
+        for company_id, password in self.state_store.iter_company_passwords():
+            LOGGER.info("Re-applying stored password for company %s", company_id)
+            self._apply_company_password(company_id, password, notify=True)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalise_company_id(company_id: Optional[int]) -> Optional[int]:
+        if company_id is None:
+            return None
+        if company_id == SPECTATOR_COMPANY_ID:
+            return None
+        return company_id

--- a/src/openttd_bot/messages.py
+++ b/src/openttd_bot/messages.py
@@ -1,0 +1,100 @@
+"""Message catalogue support for the OpenTTD helper bot."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import logging
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+DEFAULT_MESSAGES: dict[str, Any] = {
+    "welcome": [
+        "Willkommen {client_name}!",
+        "Dieser Server wird von {bot_name} betreut.",
+    ],
+    "help": [
+        "Verfügbare Befehle: !help, !rules, !pw <passwort>, !reset, !confirm.",
+        "Sende Befehle an den Server mit /server <text>.",
+    ],
+    "rules": [
+        "1. Respektiere andere Spieler.",
+        "2. Blockiere keine Strecken.",
+    ],
+    "password_instructions": [
+        "Sichere deine Firma mit /server !pw <passwort>.",
+        "Das Passwort wird automatisch nach Serverneustarts wieder gesetzt.",
+    ],
+    "password_whisper_only": "Bitte sende !pw per /server, damit dein Passwort geheim bleibt.",
+    "password_missing_argument": "Bitte gib ein Passwort an: !pw <passwort> oder !pw clear.",
+    "password_invalid": "Ungültiges Passwort.",
+    "password_set_success": "Passwort für Firma {company_name} wurde gespeichert.",
+    "password_clear_success": "Passwort für Firma {company_name} wurde entfernt.",
+    "password_not_in_company": "Du musst einer Firma angehören um ein Passwort zu setzen.",
+    "reset_not_in_company": "Du befindest dich aktuell in keiner Firma.",
+    "reset_prompt": [
+        "Du möchtest Firma {company_name} zurücksetzen.",
+        "Sende !confirm um dies zu bestätigen.",
+    ],
+    "reset_confirmed": "Firma {company_name} wurde zurückgesetzt.",
+    "reset_no_pending": "Es liegt keine offene Zurücksetzung vor.",
+    "reset_wrong_company": "Du befindest dich nicht mehr in Firma {company_name}. Reset abgebrochen.",
+    "company_password_reapplied": "Das gespeicherte Passwort für Firma {company_name} wurde erneut gesetzt.",
+}
+
+
+@dataclass(slots=True)
+class MessageCatalog:
+    """Wrapper around the user configurable message catalogue."""
+
+    data: Mapping[str, Any]
+
+    @classmethod
+    def load(cls, path: Path) -> "MessageCatalog":
+        """Load a message file from disk, falling back to defaults."""
+
+        if path.exists():
+            try:
+                with path.open("r", encoding="utf-8") as handle:
+                    loaded = json.load(handle)
+            except Exception as exc:  # pragma: no cover - defensive
+                LOGGER.warning("Failed to load messages.json, using defaults: %%s", exc)
+                loaded = {}
+        else:
+            loaded = {}
+
+        data = dict(DEFAULT_MESSAGES)
+        for key, value in loaded.items():
+            data[key] = value
+        return cls(data)
+
+    def get_lines(self, key: str, **context: Any) -> list[str]:
+        """Return a list of formatted message lines for *key*."""
+
+        raw = self.data.get(key)
+        if raw is None:
+            return []
+        if isinstance(raw, str):
+            raw_lines: Iterable[str] = [raw]
+        else:
+            raw_lines = raw
+        return [line.format(**context) for line in raw_lines]
+
+    def get_message(self, key: str, default: str = "", joiner: str = " ", **context: Any) -> str:
+        """Return a single formatted message for *key*."""
+
+        raw = self.data.get(key)
+        if raw is None:
+            return default
+        if isinstance(raw, str):
+            return raw.format(**context)
+        return joiner.join(str(part) for part in raw).format(**context)
+
+    def has(self, key: str) -> bool:
+        """Return whether a message is configured for *key*."""
+
+        return key in self.data

--- a/src/openttd_bot/messenger.py
+++ b/src/openttd_bot/messenger.py
@@ -1,0 +1,58 @@
+"""Abstractions over the pyOpenTTDAdmin client."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+from pyopenttdadmin import Admin
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AdminMessenger:
+    """High level helper for sending messages and RCON commands."""
+
+    def __init__(self, admin: Admin) -> None:
+        self._admin = admin
+
+    def send_private(self, client_id: int, message: str) -> None:
+        if not message:
+            return
+        LOGGER.debug("Sending private message to client %%s", client_id)
+        self._admin.send_private(message, client_id)
+
+    def send_private_lines(self, client_id: int, lines: Iterable[str]) -> None:
+        for line in lines:
+            self.send_private(client_id, line)
+
+    def send_company(self, company_id: int, message: str) -> None:
+        if not message:
+            return
+        LOGGER.debug("Sending company message to %%s", company_id)
+        self._admin.send_company(message, company_id)
+
+    def send_broadcast(self, message: str) -> None:
+        if not message:
+            return
+        LOGGER.debug("Sending broadcast message")
+        self._admin.send_global(message)
+
+    def set_company_password(self, company_id: int, password: str) -> None:
+        LOGGER.info("Setting password for company %s", company_id)
+        command = self._format_company_password_command(company_id, password)
+        self._admin.send_rcon(command)
+
+    def clear_company_password(self, company_id: int) -> None:
+        LOGGER.info("Clearing password for company %s", company_id)
+        command = f"company_pw {company_id} \"\""
+        self._admin.send_rcon(command)
+
+    def reset_company(self, company_id: int) -> None:
+        LOGGER.info("Resetting company %s", company_id)
+        self._admin.send_rcon(f"reset_company {company_id}")
+
+    @staticmethod
+    def _format_company_password_command(company_id: int, password: str) -> str:
+        escaped = password.replace("\\", "\\\\").replace('"', '\\"')
+        return f'company_pw {company_id} "{escaped}"'

--- a/src/openttd_bot/models.py
+++ b/src/openttd_bot/models.py
@@ -1,0 +1,38 @@
+"""Dataclasses used by the OpenTTD helper bot."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+SPECTATOR_COMPANY_ID = 255
+
+
+@dataclass(slots=True)
+class ClientState:
+    """Representation of a connected OpenTTD client."""
+
+    client_id: int
+    name: str = ""
+    company_id: Optional[int] = None
+
+    @property
+    def is_spectator(self) -> bool:
+        """Return whether the client currently spectates."""
+
+        return self.company_id is None
+
+
+@dataclass(slots=True)
+class CompanyState:
+    """Representation of a company on the server."""
+
+    company_id: int
+    name: str = ""
+    manager_name: str = ""
+    passworded: bool = False
+
+    def update_passworded(self, passworded: bool) -> None:
+        """Update the cached password state."""
+
+        self.passworded = passworded

--- a/src/openttd_bot/runner.py
+++ b/src/openttd_bot/runner.py
@@ -1,0 +1,114 @@
+"""Runtime integration with the OpenTTD admin interface."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Callable
+
+from pyopenttdadmin import Admin
+from pyopenttdadmin.enums import AdminUpdateFrequency, AdminUpdateType
+from pyopenttdadmin.packet import (
+    ChatPacket,
+    ClientInfoPacket,
+    ClientJoinPacket,
+    ClientQuitPacket,
+    ClientUpdatePacket,
+    CompanyInfoPacket,
+    CompanyNewPacket,
+    CompanyRemovePacket,
+    CompanyUpdatePacket,
+    ProtocolPacket,
+    ShutdownPacket,
+    WelcomePacket,
+)
+
+from .config import BotConfig
+from .core import BotCore
+from .messages import MessageCatalog
+from .messenger import AdminMessenger
+from .state import StateStore
+
+LOGGER = logging.getLogger(__name__)
+
+
+class BotRunner:
+    """Glue code between the Admin client and the bot core."""
+
+    def __init__(self, config: BotConfig, messages: MessageCatalog, state_store: StateStore) -> None:
+        self.config = config
+        self.messages = messages
+        self.state_store = state_store
+
+    def run(self) -> None:
+        """Run the bot forever, reconnecting on errors."""
+
+        while True:
+            try:
+                self._run_session()
+            except KeyboardInterrupt:  # pragma: no cover - handled by runner
+                LOGGER.info("Interrupted by user")
+                raise
+            except Exception as exc:  # pragma: no cover - connection errors
+                LOGGER.exception("Connection error: %s", exc)
+                time.sleep(self.config.reconnect_delay_seconds)
+
+    # ------------------------------------------------------------------
+
+    def _run_session(self) -> None:
+        LOGGER.info("Connecting to %s:%s", self.config.host, self.config.admin_port)
+        with Admin(self.config.host, self.config.admin_port) as admin:
+            messenger = AdminMessenger(admin)
+            bot = BotCore(self.config, self.messages, self.state_store, messenger)
+
+            # Register packet handlers
+            admin.add_handler(ProtocolPacket)(self._handle_protocol(bot))
+            admin.add_handler(WelcomePacket)(self._handle_welcome(bot))
+            admin.add_handler(ClientJoinPacket)(lambda _admin, packet: bot.on_client_join(packet))
+            admin.add_handler(ClientQuitPacket)(lambda _admin, packet: bot.on_client_quit(packet))
+            admin.add_handler(ClientInfoPacket)(lambda _admin, packet: bot.on_client_info(packet))
+            admin.add_handler(ClientUpdatePacket)(lambda _admin, packet: bot.on_client_update(packet))
+            admin.add_handler(CompanyNewPacket)(lambda _admin, packet: bot.on_company_info(packet))
+            admin.add_handler(CompanyInfoPacket)(lambda _admin, packet: bot.on_company_info(packet))
+            admin.add_handler(CompanyUpdatePacket)(lambda _admin, packet: bot.on_company_update(packet))
+            admin.add_handler(CompanyRemovePacket)(lambda _admin, packet: bot.on_company_remove(packet))
+            admin.add_handler(ChatPacket)(lambda _admin, packet: bot.on_chat(packet))
+            admin.add_handler(ShutdownPacket)(lambda _admin, packet: LOGGER.info("Server shutting down"))
+
+            LOGGER.info("Waiting for server protocol packet")
+            admin.run()
+
+    # ------------------------------------------------------------------
+
+    def _handle_protocol(self, bot: BotCore) -> Callable[[Admin, ProtocolPacket], None]:
+        def handler(admin: Admin, packet: ProtocolPacket) -> None:
+            LOGGER.info("Received protocol packet version %s", packet.version)
+            admin.login(self.config.bot_name, self.config.admin_password)
+
+        return handler
+
+    def _handle_welcome(self, bot: BotCore) -> Callable[[Admin, WelcomePacket], None]:
+        def handler(admin: Admin, packet: WelcomePacket) -> None:
+            LOGGER.info("Logged in as %s", self.config.bot_name)
+            bot.on_welcome(packet)
+            admin.subscribe(AdminUpdateType.CLIENT_INFO, AdminUpdateFrequency.AUTOMATIC)
+            admin.subscribe(AdminUpdateType.COMPANY_INFO, AdminUpdateFrequency.AUTOMATIC)
+            admin.subscribe(AdminUpdateType.CHAT, AdminUpdateFrequency.AUTOMATIC)
+            self._schedule_reapply(bot)
+
+        return handler
+
+    def _schedule_reapply(self, bot: BotCore) -> None:
+        delay = max(0, self.config.startup_reapply_delay_seconds)
+        if delay == 0:
+            bot.reapply_stored_passwords()
+            return
+
+        def worker() -> None:
+            LOGGER.info("Waiting %s seconds before reapplying passwords", delay)
+            time.sleep(delay)
+            bot.reapply_stored_passwords()
+
+        thread = threading.Thread(target=worker, name="password-reapply", daemon=True)
+        thread.start()

--- a/src/openttd_bot/state.py
+++ b/src/openttd_bot/state.py
@@ -1,0 +1,81 @@
+"""Persistent state handling for the OpenTTD helper bot."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import logging
+from pathlib import Path
+from threading import Lock
+from typing import Dict, Iterator
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class PersistentState:
+    """Container for the on-disk state."""
+
+    companies: Dict[str, str] = field(default_factory=dict)
+
+
+class StateStore:
+    """Manage persisted state on disk."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._lock = Lock()
+        self._state = PersistentState()
+        self._load()
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            with self.path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except Exception as exc:  # pragma: no cover - defensive
+            LOGGER.warning("Could not read state file %s: %s", self.path, exc)
+            return
+        companies = data.get("companies", {})
+        if isinstance(companies, dict):
+            self._state.companies = {
+                str(company_id): str(password)
+                for company_id, password in companies.items()
+                if password is not None
+            }
+
+    def _write(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.path.with_suffix(".tmp")
+        with tmp_path.open("w", encoding="utf-8") as handle:
+            json.dump({"companies": self._state.companies}, handle, indent=2, ensure_ascii=False)
+        tmp_path.replace(self.path)
+
+    def get_company_password(self, company_id: int) -> str | None:
+        """Return the stored password for *company_id* if present."""
+
+        with self._lock:
+            return self._state.companies.get(str(company_id))
+
+    def set_company_password(self, company_id: int, password: str) -> None:
+        """Persist the password for *company_id*."""
+
+        with self._lock:
+            self._state.companies[str(company_id)] = password
+            self._write()
+
+    def clear_company_password(self, company_id: int) -> None:
+        """Remove any stored password for *company_id*."""
+
+        with self._lock:
+            if str(company_id) in self._state.companies:
+                del self._state.companies[str(company_id)]
+                self._write()
+
+    def iter_company_passwords(self) -> Iterator[tuple[int, str]]:
+        """Yield all stored company passwords."""
+
+        with self._lock:
+            for company_id, password in self._state.companies.items():
+                yield int(company_id), password

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import List, Tuple
+
+import pytest
+
+from openttd_bot.config import BotConfig
+from openttd_bot.core import BotCore
+from openttd_bot.messages import DEFAULT_MESSAGES, MessageCatalog
+from openttd_bot.models import SPECTATOR_COMPANY_ID
+from openttd_bot.state import StateStore
+from pyopenttdadmin.enums import Actions, ChatDestTypes
+
+
+class FakeMessenger:
+    def __init__(self) -> None:
+        self.private_messages: List[Tuple[int, str]] = []
+        self.company_messages: List[Tuple[int, str]] = []
+        self.broadcasts: List[str] = []
+        self.commands: List[Tuple[str, int, str | None]] = []
+
+    def send_private(self, client_id: int, message: str) -> None:
+        self.private_messages.append((client_id, message))
+
+    def send_private_lines(self, client_id: int, lines) -> None:
+        for line in lines:
+            self.send_private(client_id, line)
+
+    def send_company(self, company_id: int, message: str) -> None:
+        self.company_messages.append((company_id, message))
+
+    def send_broadcast(self, message: str) -> None:
+        self.broadcasts.append(message)
+
+    def set_company_password(self, company_id: int, password: str) -> None:
+        self.commands.append(("set_pw", company_id, password))
+
+    def clear_company_password(self, company_id: int) -> None:
+        self.commands.append(("clear_pw", company_id, None))
+
+    def reset_company(self, company_id: int) -> None:
+        self.commands.append(("reset", company_id, None))
+
+    def reset_messages(self) -> None:
+        self.private_messages.clear()
+        self.company_messages.clear()
+        self.broadcasts.clear()
+        self.commands.clear()
+
+
+@pytest.fixture
+def bot(tmp_path):
+    config = BotConfig(
+        host="localhost",
+        admin_port=3977,
+        admin_password="admin",
+        bot_name="ServerBot",
+        command_prefix="!",
+        state_file=tmp_path / "state.json",
+        messages_file=tmp_path / "messages.json",
+        startup_reapply_delay_seconds=0,
+        reconnect_delay_seconds=5,
+    )
+    messages = MessageCatalog(dict(DEFAULT_MESSAGES))
+    state_store = StateStore(config.state_file)
+    messenger = FakeMessenger()
+    core = BotCore(config, messages, state_store, messenger)  # type: ignore[arg-type]
+    return core, messenger, state_store
+
+
+def make_chat(client_id: int, message: str, dest: ChatDestTypes = ChatDestTypes.BROADCAST):
+    return SimpleNamespace(
+        action=Actions.CHAT if dest != ChatDestTypes.CLIENT else Actions.CHAT_CLIENT,
+        desttype=dest,
+        id=client_id,
+        message=message,
+        money=0,
+    )
+
+
+def test_join_sends_welcome_help_and_rules(bot):
+    core, messenger, _ = bot
+    core.on_welcome(SimpleNamespace(server_name="TestServer"))
+    core.on_client_info(SimpleNamespace(id=1, name="Alice", company_id=SPECTATOR_COMPANY_ID))
+    assert messenger.private_messages[:6] == [
+        (1, "Willkommen Alice!"),
+        (1, "Dieser Server wird von ServerBot betreut."),
+        (1, "Verfügbare Befehle: !help, !rules, !pw <passwort>, !reset, !confirm."),
+        (1, "Sende Befehle an den Server mit /server <text>."),
+        (1, "1. Respektiere andere Spieler."),
+        (1, "2. Blockiere keine Strecken."),
+    ]
+
+
+def test_help_command_sends_help(bot):
+    core, messenger, _ = bot
+    core.on_client_info(SimpleNamespace(id=1, name="Alice", company_id=SPECTATOR_COMPANY_ID))
+    messenger.reset_messages()
+    core.on_chat(make_chat(1, "!help"))
+    assert messenger.private_messages == [
+        (1, "Verfügbare Befehle: !help, !rules, !pw <passwort>, !reset, !confirm."),
+        (1, "Sende Befehle an den Server mit /server <text>."),
+    ]
+
+
+def test_password_requires_private(bot):
+    core, messenger, state_store = bot
+    core.on_company_info(SimpleNamespace(id=3, name="Firma 3", manager_name="", passworded=False))
+    core.on_client_info(SimpleNamespace(id=5, name="Bob", company_id=3))
+    messenger.reset_messages()
+    core.on_chat(make_chat(5, "!pw geheim", ChatDestTypes.BROADCAST))
+    assert messenger.private_messages == [
+        (5, "Bitte sende !pw per /server, damit dein Passwort geheim bleibt."),
+    ]
+    assert state_store.get_company_password(3) is None
+    assert messenger.commands == []
+
+
+def test_password_private_sets_and_persists(bot):
+    core, messenger, state_store = bot
+    core.on_company_info(SimpleNamespace(id=2, name="Firma 2", manager_name="", passworded=False))
+    core.on_client_info(SimpleNamespace(id=7, name="Cara", company_id=2))
+    messenger.reset_messages()
+    core.on_chat(make_chat(7, "!pw geheim", ChatDestTypes.CLIENT))
+    assert state_store.get_company_password(2) == "geheim"
+    assert ("set_pw", 2, "geheim") in messenger.commands
+    assert messenger.private_messages[-1] == (7, "Passwort für Firma Firma 2 wurde gespeichert.")
+
+
+def test_password_clear(bot):
+    core, messenger, state_store = bot
+    core.on_company_info(SimpleNamespace(id=4, name="Firma 4", manager_name="", passworded=True))
+    core.on_client_info(SimpleNamespace(id=8, name="Dora", company_id=4))
+    state_store.set_company_password(4, "alt")
+    messenger.reset_messages()
+    core.on_chat(make_chat(8, "!pw clear", ChatDestTypes.CLIENT))
+    assert state_store.get_company_password(4) is None
+    assert ("clear_pw", 4, None) in messenger.commands
+    assert messenger.private_messages[-1] == (8, "Passwort für Firma Firma 4 wurde entfernt.")
+
+
+def test_reset_and_confirm(bot):
+    core, messenger, state_store = bot
+    core.on_company_info(SimpleNamespace(id=6, name="Firma 6", manager_name="", passworded=True))
+    core.on_client_info(SimpleNamespace(id=9, name="Eve", company_id=6))
+    messenger.reset_messages()
+    core.on_chat(make_chat(9, "!reset"))
+    assert (9, "Du möchtest Firma Firma 6 zurücksetzen.") in messenger.private_messages
+    core.on_chat(make_chat(9, "!confirm"))
+    assert ("reset", 6, None) in messenger.commands
+    assert messenger.private_messages[-1] == (9, "Firma Firma 6 wurde zurückgesetzt.")
+
+
+def test_reset_requires_same_company(bot):
+    core, messenger, _ = bot
+    core.on_company_info(SimpleNamespace(id=10, name="Firma 10", manager_name="", passworded=True))
+    core.on_client_info(SimpleNamespace(id=11, name="Fred", company_id=10))
+    messenger.reset_messages()
+    core.on_chat(make_chat(11, "!reset"))
+    core.on_client_update(SimpleNamespace(id=11, name="Fred", company_id=SPECTATOR_COMPANY_ID))
+    core.on_chat(make_chat(11, "!confirm"))
+    assert messenger.private_messages[-1] == (11, "Du befindest dich nicht mehr in Firma Firma 10. Reset abgebrochen.")
+    assert not any(cmd for cmd in messenger.commands if cmd[0] == "reset")
+
+
+def test_reapply_password_on_company_info(bot):
+    core, messenger, state_store = bot
+    state_store.set_company_password(12, "schutz")
+    core.on_client_info(SimpleNamespace(id=13, name="Gina", company_id=12))
+    messenger.reset_messages()
+    core.on_company_info(SimpleNamespace(id=12, name="Firma 12", manager_name="", passworded=False))
+    assert ("set_pw", 12, "schutz") in messenger.commands
+    assert messenger.private_messages[-1] == (13, "Das gespeicherte Passwort für Firma Firma 12 wurde erneut gesetzt.")
+
+
+def test_reapply_all_passwords(bot):
+    core, messenger, state_store = bot
+    state_store.set_company_password(20, "eins")
+    state_store.set_company_password(21, "zwei")
+    core.reapply_stored_passwords()
+    assert ("set_pw", 20, "eins") in messenger.commands
+    assert ("set_pw", 21, "zwei") in messenger.commands


### PR DESCRIPTION
## Summary
- implement the core bot logic to react to chat commands, manage company passwords and coordinate resets
- wire the bot into the OpenTTD admin interface with configuration, messaging defaults and a runnable entrypoint
- provide documentation, sample messages and automated tests that cover command parsing and password reapplication

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca85490af88321bad22031dab3ef64