### PR TITLE
Improve admin connection diagnostics

### DIFF
--- a/src/openttd_bot/runner.py
+++ b/src/openttd_bot/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import socket
 import shutil
 import subprocess
 import threading
@@ -37,6 +38,109 @@ LOGGER = logging.getLogger(__name__)
 PROTOCOL_WATCHDOG_INTERVAL_SECONDS = 10
 
 
+class InstrumentedAdmin(Admin):
+    """Admin client with additional diagnostics for connection issues."""
+
+    socket_timeout_seconds = 0.5
+
+    def __init__(self, host: str, port: int) -> None:
+        super().__init__(host, port)
+        # ``Admin.__init__`` sets the socket timeout, store it for reference.
+        try:
+            timeout = self.socket.gettimeout()
+        except OSError:
+            timeout = None
+        self.socket_timeout_seconds = float(timeout or 0.5)
+        self.empty_read_count = 0
+        self.protocol_received = False
+        self.last_socket_error: str | None = None
+        self.last_raw_bytes: bytes = b""
+
+    # ------------------------------------------------------------------
+
+    def mark_protocol_received(self) -> None:
+        self.protocol_received = True
+        self.empty_read_count = 0
+
+    # ------------------------------------------------------------------
+
+    def debug_state(self) -> str:
+        parts = [
+            f"protocol_received={self.protocol_received}",
+            f"empty_reads={self.empty_read_count}",
+        ]
+        if self.last_socket_error:
+            parts.append(f"last_socket_error={self.last_socket_error}")
+
+        if self.last_raw_bytes:
+            parts.append(f"last_bytes={self.last_raw_bytes.hex()}")
+
+        try:
+            remote = self.socket.getpeername()
+            local = self.socket.getsockname()
+        except OSError as exc:
+            parts.append(f"peer=unavailable({exc})")
+        else:
+            parts.append(f"peer={remote}")
+            parts.append(f"local={local}")
+
+        parts.append(f"socket_timeout={self.socket_timeout_seconds}")
+        return ", ".join(parts)
+
+    # ------------------------------------------------------------------
+
+    def _recv(self, size: int) -> bytes:  # noqa: D401 - inherited docstring
+        try:
+            data = self.socket.recv(size)
+        except socket.timeout:
+            if not self.protocol_received:
+                self.empty_read_count += 1
+                if LOGGER.isEnabledFor(logging.DEBUG):
+                    LOGGER.debug(
+                        "Admin socket timed out waiting for %s bytes (%s consecutive empty reads)",
+                        size,
+                        self.empty_read_count,
+                    )
+            return b""
+        except OSError as exc:
+            self.last_socket_error = f"{exc.__class__.__name__}: {exc}"
+            LOGGER.warning("Socket error while reading admin data: %s", self.last_socket_error)
+            raise
+
+        self.last_socket_error = None
+
+        if not data:
+            LOGGER.warning(
+                "Admin socket closed by remote host after %s consecutive empty reads",
+                self.empty_read_count,
+            )
+            raise ConnectionAbortedError("Server closed the admin connection")
+
+        if not self.protocol_received:
+            if self.empty_read_count:
+                if LOGGER.isEnabledFor(logging.DEBUG):
+                    LOGGER.debug(
+                        "Received %s bytes after %s empty reads while waiting for protocol packet",
+                        len(data),
+                        self.empty_read_count,
+                    )
+                self.empty_read_count = 0
+
+            if LOGGER.isEnabledFor(logging.DEBUG):
+                self.last_raw_bytes = data[:32]
+                LOGGER.debug(
+                    "Received %s raw bytes from admin socket: %s",
+                    len(data),
+                    self.last_raw_bytes.hex(),
+                )
+            else:
+                self.last_raw_bytes = data[:32]
+        else:
+            self.last_raw_bytes = data[:32]
+
+        return data
+
+
 class BotRunner:
     """Glue code between the Admin client and the bot core."""
 
@@ -62,7 +166,7 @@ class BotRunner:
 
     def _run_session(self) -> None:
         LOGGER.info("Connecting to %s:%s", self.config.host, self.config.admin_port)
-        with Admin(self.config.host, self.config.admin_port) as admin:
+        with InstrumentedAdmin(self.config.host, self.config.admin_port) as admin:
             messenger = AdminMessenger(admin)
             bot = BotCore(self.config, self.messages, self.state_store, messenger)
             protocol_event = threading.Event()
@@ -85,13 +189,25 @@ class BotRunner:
             watchdog = threading.Thread(
                 target=self._protocol_watchdog,
                 name="protocol-watchdog",
-                args=(protocol_event,),
+                args=(admin, protocol_event),
                 daemon=True,
             )
             watchdog.start()
 
             try:
                 admin.run()
+            except ConnectionAbortedError:
+                if not protocol_event.is_set():
+                    details = ""
+                    if hasattr(admin, "debug_state"):
+                        try:
+                            details = f" ({admin.debug_state()})"
+                        except Exception:  # pragma: no cover - defensive logging
+                            LOGGER.debug("Failed to collect admin debug state", exc_info=True)
+                    LOGGER.error(
+                        "Admin connection closed before receiving protocol packet%s", details
+                    )
+                raise
             finally:
                 protocol_event.set()
 
@@ -103,6 +219,11 @@ class BotRunner:
         def handler(admin: Admin, packet: ProtocolPacket) -> None:
             LOGGER.info("Received protocol packet version %s", packet.version)
             protocol_event.set()
+            if hasattr(admin, "mark_protocol_received"):
+                try:
+                    admin.mark_protocol_received()
+                except Exception:  # pragma: no cover - defensive logging
+                    LOGGER.debug("Failed to mark protocol as received", exc_info=True)
             admin.login(self.config.bot_name, self.config.admin_password)
 
         return handler
@@ -134,9 +255,10 @@ class BotRunner:
 
     # ------------------------------------------------------------------
 
-    def _protocol_watchdog(self, protocol_event: threading.Event) -> None:
+    def _protocol_watchdog(self, admin: Admin, protocol_event: threading.Event) -> None:
         wait_interval = max(1, PROTOCOL_WATCHDOG_INTERVAL_SECONDS)
         waited = wait_interval
+        last_logged_empty_reads = -1
 
         while not protocol_event.wait(wait_interval):
             if waited == wait_interval:
@@ -155,6 +277,11 @@ class BotRunner:
                     self.config.admin_port,
                     waited,
                 )
+            last_logged_empty_reads = self._log_admin_socket_state(
+                admin,
+                waited,
+                last_logged_empty_reads,
+            )
             waited += wait_interval
 
     def _log_connectivity_probe(self) -> None:
@@ -187,3 +314,38 @@ class BotRunner:
             LOGGER.info("netcat stderr:\n%s", result.stderr.strip())
 
         LOGGER.info("netcat exited with return code %s", result.returncode)
+
+    def _log_admin_socket_state(
+        self,
+        admin: Admin,
+        waited_seconds: int,
+        last_logged_empty_reads: int,
+    ) -> int:
+        """Log diagnostic information about the admin socket state."""
+
+        empty_reads = getattr(admin, "empty_read_count", None)
+
+        if empty_reads is not None:
+            if last_logged_empty_reads == -1:
+                if empty_reads:
+                    LOGGER.warning(
+                        "No data received from admin port after %s seconds (%s consecutive empty reads)",
+                        waited_seconds,
+                        empty_reads,
+                    )
+                else:
+                    LOGGER.debug(
+                        "Admin socket reported no empty reads after %s seconds", waited_seconds
+                    )
+            elif empty_reads != last_logged_empty_reads:
+                LOGGER.debug(
+                    "Still waiting for protocol packet: %s consecutive empty reads observed", empty_reads
+                )
+
+        if last_logged_empty_reads == -1 and hasattr(admin, "debug_state"):
+            try:
+                LOGGER.debug("Admin socket debug snapshot: %s", admin.debug_state())
+            except Exception:  # pragma: no cover - defensive logging
+                LOGGER.debug("Failed to capture admin socket debug state", exc_info=True)
+
+        return empty_reads if empty_reads is not None else last_logged_empty_reads


### PR DESCRIPTION
## Summary
- wrap the admin client in a new InstrumentedAdmin helper that records socket state while waiting for the handshake
- surface richer diagnostics when the protocol packet is missing and the server closes the connection
- log admin socket statistics from the protocol watchdog to highlight repeated empty reads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbb342aab48321aabce96e044403bb