### PR TITLE
Fix admin chat name and 1-based company IDs

### DIFF
--- a/src/openttd_bot/messenger.py
+++ b/src/openttd_bot/messenger.py
@@ -38,19 +38,36 @@ class AdminMessenger:
         LOGGER.debug("Sending broadcast message")
         self._admin.send_global(message)
 
+    def set_admin_name(self, name: str) -> None:
+        """Update the server-side chat name used for admin messages."""
+
+        if not name:
+            return
+        escaped = name.replace("\\", "\\\\").replace('"', '\\"')
+        LOGGER.info("Setting admin chat name to %s", name)
+        self._admin.send_rcon(f'name "{escaped}"')
+
+    def _to_rcon_company_id(self, company_id: int) -> int:
+        """Return the 1-based company identifier expected by RCON commands."""
+
+        return company_id + 1
+
     def set_company_password(self, company_id: int, password: str) -> None:
-        LOGGER.info("Setting password for company %s", company_id)
-        command = self._format_company_password_command(company_id, password)
+        company_number = self._to_rcon_company_id(company_id)
+        LOGGER.info("Setting password for company %s", company_number)
+        command = self._format_company_password_command(company_number, password)
         self._admin.send_rcon(command)
 
     def clear_company_password(self, company_id: int) -> None:
-        LOGGER.info("Clearing password for company %s", company_id)
-        command = f"company_pw {company_id} \"\""
+        company_number = self._to_rcon_company_id(company_id)
+        LOGGER.info("Clearing password for company %s", company_number)
+        command = f"company_pw {company_number} \"\""
         self._admin.send_rcon(command)
 
     def reset_company(self, company_id: int) -> None:
-        LOGGER.info("Resetting company %s", company_id)
-        self._admin.send_rcon(f"reset_company {company_id}")
+        company_number = self._to_rcon_company_id(company_id)
+        LOGGER.info("Resetting company %s", company_number)
+        self._admin.send_rcon(f"reset_company {company_number}")
 
     @staticmethod
     def _format_company_password_command(company_id: int, password: str) -> str:

--- a/src/openttd_bot/runner.py
+++ b/src/openttd_bot/runner.py
@@ -173,7 +173,7 @@ class BotRunner:
 
             # Register packet handlers
             admin.add_handler(ProtocolPacket)(self._handle_protocol(bot, protocol_event))
-            admin.add_handler(WelcomePacket)(self._handle_welcome(bot))
+            admin.add_handler(WelcomePacket)(self._handle_welcome(bot, messenger))
             admin.add_handler(ClientJoinPacket)(lambda _admin, packet: bot.on_client_join(packet))
             admin.add_handler(ClientQuitPacket)(lambda _admin, packet: bot.on_client_quit(packet))
             admin.add_handler(ClientInfoPacket)(lambda _admin, packet: bot.on_client_info(packet))
@@ -230,10 +230,14 @@ class BotRunner:
 
         return handler
 
-    def _handle_welcome(self, bot: BotCore) -> Callable[[Admin, WelcomePacket], None]:
+    def _handle_welcome(self, bot: BotCore, messenger: AdminMessenger) -> Callable[[Admin, WelcomePacket], None]:
         def handler(admin: Admin, packet: WelcomePacket) -> None:
             LOGGER.info("Logged in as %s", self.config.bot_name)
             bot.on_welcome(packet)
+            try:
+                messenger.set_admin_name(self.config.bot_name)
+            except Exception:  # pragma: no cover - defensive logging
+                LOGGER.exception("Failed to set admin chat name")
             admin.subscribe(AdminUpdateType.CLIENT_INFO, AdminUpdateFrequency.AUTOMATIC)
             admin.subscribe(AdminUpdateType.COMPANY_INFO, AdminUpdateFrequency.AUTOMATIC)
             admin.subscribe(AdminUpdateType.CHAT, AdminUpdateFrequency.AUTOMATIC)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -34,13 +34,13 @@ class FakeMessenger:
         self.broadcasts.append(message)
 
     def set_company_password(self, company_id: int, password: str) -> None:
-        self.commands.append(("set_pw", company_id, password))
+        self.commands.append(("set_pw", company_id + 1, password))
 
     def clear_company_password(self, company_id: int) -> None:
-        self.commands.append(("clear_pw", company_id, None))
+        self.commands.append(("clear_pw", company_id + 1, None))
 
     def reset_company(self, company_id: int) -> None:
-        self.commands.append(("reset", company_id, None))
+        self.commands.append(("reset", company_id + 1, None))
 
     def reset_messages(self) -> None:
         self.private_messages.clear()
@@ -124,7 +124,7 @@ def test_password_private_sets_and_persists(bot):
     messenger.reset_messages()
     core.on_chat(make_chat(7, "!pw geheim", ChatDestTypes.CLIENT))
     assert state_store.get_company_password(2) == "geheim"
-    assert ("set_pw", 2, "geheim") in messenger.commands
+    assert ("set_pw", 3, "geheim") in messenger.commands
     assert messenger.private_messages[-1] == (7, "Passwort für Firma Firma 2 wurde gespeichert.")
 
 
@@ -136,7 +136,7 @@ def test_password_clear(bot):
     messenger.reset_messages()
     core.on_chat(make_chat(8, "!pw clear", ChatDestTypes.CLIENT))
     assert state_store.get_company_password(4) is None
-    assert ("clear_pw", 4, None) in messenger.commands
+    assert ("clear_pw", 5, None) in messenger.commands
     assert messenger.private_messages[-1] == (8, "Passwort für Firma Firma 4 wurde entfernt.")
 
 
@@ -148,7 +148,7 @@ def test_reset_and_confirm(bot):
     core.on_chat(make_chat(9, "!reset"))
     assert (9, "Du möchtest Firma Firma 6 zurücksetzen.") in messenger.private_messages
     core.on_chat(make_chat(9, "!confirm"))
-    assert ("reset", 6, None) in messenger.commands
+    assert ("reset", 7, None) in messenger.commands
     assert messenger.private_messages[-1] == (9, "Firma Firma 6 wurde zurückgesetzt.")
 
 
@@ -170,7 +170,7 @@ def test_reapply_password_on_company_info(bot):
     core.on_client_info(SimpleNamespace(id=13, name="Gina", company_id=12))
     messenger.reset_messages()
     core.on_company_info(SimpleNamespace(id=12, name="Firma 12", manager_name="", passworded=False))
-    assert ("set_pw", 12, "schutz") in messenger.commands
+    assert ("set_pw", 13, "schutz") in messenger.commands
     assert messenger.private_messages[-1] == (13, "Das gespeicherte Passwort für Firma Firma 12 wurde erneut gesetzt.")
 
 
@@ -179,5 +179,5 @@ def test_reapply_all_passwords(bot):
     state_store.set_company_password(20, "eins")
     state_store.set_company_password(21, "zwei")
     core.reapply_stored_passwords()
-    assert ("set_pw", 20, "eins") in messenger.commands
-    assert ("set_pw", 21, "zwei") in messenger.commands
+    assert ("set_pw", 21, "eins") in messenger.commands
+    assert ("set_pw", 22, "zwei") in messenger.commands


### PR DESCRIPTION
## Summary
- set the admin chat name via RCON after connecting so messages use the configured bot name
- treat company numbers as 1-based in messages and convert RCON commands to the expected IDs
- adjust automated tests for the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbbb2e554483218f5abc44b2bf33b1