### PR TITLE
Fix RCON company numbering

### DIFF
--- a/src/openttd_bot/messenger.py
+++ b/src/openttd_bot/messenger.py
@@ -50,9 +50,10 @@ class AdminMessenger:
     def _to_rcon_company_id(self, company_id: int) -> int:
         """Return the company identifier expected by RCON commands."""
 
-        # The admin API already uses the company numbering required by RCON
-        # commands, so no further conversion is necessary.
-        return company_id
+        # Company identifiers exposed by the admin protocol are zero-based,
+        # while RCON commands expect them to be one-based. Convert here so that
+        # callers can continue to use the admin identifiers everywhere else.
+        return company_id + 1
 
     def set_company_password(self, company_id: int, password: str) -> None:
         company_number = self._to_rcon_company_id(company_id)

--- a/tests/test_messenger.py
+++ b/tests/test_messenger.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from openttd_bot.messenger import AdminMessenger
+
+
+class DummyAdmin:
+    def __init__(self) -> None:
+        self.rcon_commands: list[str] = []
+
+    def send_rcon(self, command: str) -> None:  # pragma: no cover - simple stub
+        self.rcon_commands.append(command)
+
+
+def test_rcon_commands_use_one_based_company_ids() -> None:
+    admin = DummyAdmin()
+    messenger = AdminMessenger(admin)  # type: ignore[arg-type]
+
+    messenger.set_company_password(5, "secret")
+    messenger.clear_company_password(5)
+    messenger.reset_company(5)
+
+    assert admin.rcon_commands == [
+        'company_pw 6 "secret"',
+        'company_pw 6 ""',
+        'reset_company 6',
+    ]


### PR DESCRIPTION
## Summary
- ensure RCON commands use one-based company identifiers
- add a regression test covering the AdminMessenger RCON commands

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbc7b9bdcc83219c9cc51d446fcc82