### PR TITLE
Update instructions for private password submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ein Python-Bot, der über den Admin-Port eines OpenTTD-Servers läuft und dabei 
 ## Features
 
 - Reagiert auf Befehle `!help`, `!rules`, `!pw`, `!reset` und `!confirm` sowohl im öffentlichen Chat als auch per Flüstern.
-- Erzwingt, dass Passwörter ausschließlich per `/whisper <BotName> !pw <passwort>` privat übermittelt werden.
+- Erzwingt, dass Passwörter ausschließlich per privater Nachricht über die Spielerauswahl übermittelt werden (`!pw <passwort>` an den Bot flüstern).
 - Speichert Firmenpasswörter persistent und setzt sie nach einem Serverneustart automatisch wieder.
 - Schickt neuen Spielern automatisch eine Begrüßung sowie Hilfe- und Regelhinweise.
 - Informiert neue Firmeninhaber direkt darüber, wie ein Passwort gesetzt wird.
@@ -173,7 +173,7 @@ Veröffentlicht unter der MIT-Lizenz (siehe `LICENSE`).
 ### Features
 
 - Responds to `!help`, `!rules`, `!pw`, `!reset` and `!confirm` in public chat and via whispers.
-- Enforces password submission via private message (`/whisper <BotName> !pw <password>`).
+- Enforces password submission via private whisper using the player list (`!pw <password>` sent directly to the bot).
 - Persists company passwords and reapplies them after the server restarts.
 - Welcomes new players automatically and shares help/rules messages.
 - Informs new company owners how to set a password.

--- a/messages.json
+++ b/messages.json
@@ -8,8 +8,8 @@
   "help": [
     "[DE] Verfügbare Befehle: !help, !rules, !pw <passwort>, !reset, !confirm.",
     "[EN] Available commands: !help, !rules, !pw <password>, !reset, !confirm.",
-    "[DE] Nutze /whisper {bot_name} !pw <passwort>, damit dein Passwort privat bleibt.",
-    "[EN] Use /whisper {bot_name} !pw <password> to keep your password private."
+    "[DE] Öffne die Spielerauswahl (Spieler-Button oder Strg+P), wähle {bot_name} und nutze die Flüstern-Funktion, um !pw <passwort> privat zu senden.",
+    "[EN] Open the player selection (Players button or Ctrl+P), select {bot_name} and use the whisper function to send !pw <password> privately."
   ],
   "rules": [
     "[DE] 1. Respektiere andere Spieler.",
@@ -18,14 +18,14 @@
     "[EN] 2. Do not block tracks."
   ],
   "password_instructions": [
-    "[DE] Flüstere {bot_name} mit /whisper {bot_name} !pw <passwort>, um deine Firma zu schützen.",
-    "[EN] Whisper {bot_name} using /whisper {bot_name} !pw <password> to protect your company.",
+    "[DE] Flüstere {bot_name} über die Spielerauswahl (Spieler-Button oder Strg+P) mit !pw <passwort>, um deine Firma zu schützen.",
+    "[EN] Whisper {bot_name} via the player selection (Players button or Ctrl+P) using !pw <password> to protect your company.",
     "[DE] Nach Serverneustarts setzt der Bot das gespeicherte Passwort automatisch wieder.",
     "[EN] The bot will automatically restore the saved password after server restarts."
   ],
   "password_whisper_only": [
-    "[DE] Bitte sende Firmenpasswörter nur per /whisper {bot_name} !pw <passwort>, nicht im öffentlichen Chat.",
-    "[EN] Please submit company passwords only via /whisper {bot_name} !pw <password>, never in public chat."
+    "[DE] Bitte nutze die Spielerauswahl, wähle {bot_name} und sende dort !pw <passwort>, nicht im öffentlichen Chat.",
+    "[EN] Please use the player selection, pick {bot_name} and send !pw <password> there instead of public chat."
   ],
   "password_missing_argument": [
     "[DE] Bitte gib ein Passwort an: !pw <passwort> oder !pw clear.",

--- a/src/openttd_bot/messages.py
+++ b/src/openttd_bot/messages.py
@@ -22,8 +22,8 @@ DEFAULT_MESSAGES: dict[str, Any] = {
     "help": [
         "[DE] Verfügbare Befehle: !help, !rules, !pw <passwort>, !reset, !confirm.",
         "[EN] Available commands: !help, !rules, !pw <password>, !reset, !confirm.",
-        "[DE] Nutze /whisper {bot_name} !pw <passwort>, damit dein Passwort privat bleibt.",
-        "[EN] Use /whisper {bot_name} !pw <password> to keep your password private.",
+        "[DE] Öffne die Spielerauswahl (Spieler-Button oder Strg+P), wähle {bot_name} und nutze die Flüstern-Funktion, um !pw <passwort> privat zu senden.",
+        "[EN] Open the player selection (Players button or Ctrl+P), select {bot_name} and use the whisper function to send !pw <password> privately.",
     ],
     "rules": [
         "[DE] 1. Respektiere andere Spieler.",
@@ -32,14 +32,14 @@ DEFAULT_MESSAGES: dict[str, Any] = {
         "[EN] 2. Do not block tracks.",
     ],
     "password_instructions": [
-        "[DE] Flüstere {bot_name} mit /whisper {bot_name} !pw <passwort>, um deine Firma zu schützen.",
-        "[EN] Whisper {bot_name} using /whisper {bot_name} !pw <password> to protect your company.",
+        "[DE] Flüstere {bot_name} über die Spielerauswahl (Spieler-Button oder Strg+P) mit !pw <passwort>, um deine Firma zu schützen.",
+        "[EN] Whisper {bot_name} via the player selection (Players button or Ctrl+P) using !pw <password> to protect your company.",
         "[DE] Nach Serverneustarts setzt der Bot das gespeicherte Passwort automatisch wieder.",
         "[EN] The bot will automatically restore the saved password after server restarts.",
     ],
     "password_whisper_only": [
-        "[DE] Bitte sende Firmenpasswörter nur per /whisper {bot_name} !pw <passwort>, nicht im öffentlichen Chat.",
-        "[EN] Please submit company passwords only via /whisper {bot_name} !pw <password>, never in public chat.",
+        "[DE] Bitte nutze die Spielerauswahl, wähle {bot_name} und sende dort !pw <passwort>, nicht im öffentlichen Chat.",
+        "[EN] Please use the player selection, pick {bot_name} and send !pw <password> there instead of public chat.",
     ],
     "password_missing_argument": [
         "[DE] Bitte gib ein Passwort an: !pw <passwort> oder !pw clear.",

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -90,8 +90,8 @@ def test_join_sends_welcome_help_and_rules(bot):
         (1, "[EN] This server is maintained by ServerBot."),
         (1, "[DE] Verfügbare Befehle: !help, !rules, !pw <passwort>, !reset, !confirm."),
         (1, "[EN] Available commands: !help, !rules, !pw <password>, !reset, !confirm."),
-        (1, "[DE] Nutze /whisper ServerBot !pw <passwort>, damit dein Passwort privat bleibt."),
-        (1, "[EN] Use /whisper ServerBot !pw <password> to keep your password private."),
+        (1, "[DE] Öffne die Spielerauswahl (Spieler-Button oder Strg+P), wähle ServerBot und nutze die Flüstern-Funktion, um !pw <passwort> privat zu senden."),
+        (1, "[EN] Open the player selection (Players button or Ctrl+P), select ServerBot and use the whisper function to send !pw <password> privately."),
         (1, "[DE] 1. Respektiere andere Spieler."),
         (1, "[EN] 1. Respect other players."),
         (1, "[DE] 2. Blockiere keine Strecken."),
@@ -107,8 +107,8 @@ def test_help_command_sends_help(bot):
     assert messenger.private_messages == [
         (1, "[DE] Verfügbare Befehle: !help, !rules, !pw <passwort>, !reset, !confirm."),
         (1, "[EN] Available commands: !help, !rules, !pw <password>, !reset, !confirm."),
-        (1, "[DE] Nutze /whisper ServerBot !pw <passwort>, damit dein Passwort privat bleibt."),
-        (1, "[EN] Use /whisper ServerBot !pw <password> to keep your password private."),
+        (1, "[DE] Öffne die Spielerauswahl (Spieler-Button oder Strg+P), wähle ServerBot und nutze die Flüstern-Funktion, um !pw <passwort> privat zu senden."),
+        (1, "[EN] Open the player selection (Players button or Ctrl+P), select ServerBot and use the whisper function to send !pw <password> privately."),
     ]
 
 
@@ -119,8 +119,8 @@ def test_password_requires_private(bot):
     messenger.reset_messages()
     core.on_chat(make_chat(5, "!pw geheim", ChatDestTypes.BROADCAST))
     assert messenger.private_messages == [
-        (5, "[DE] Bitte sende Firmenpasswörter nur per /whisper ServerBot !pw <passwort>, nicht im öffentlichen Chat."),
-        (5, "[EN] Please submit company passwords only via /whisper ServerBot !pw <password>, never in public chat."),
+        (5, "[DE] Bitte nutze die Spielerauswahl, wähle ServerBot und sende dort !pw <passwort>, nicht im öffentlichen Chat."),
+        (5, "[EN] Please use the player selection, pick ServerBot and send !pw <password> there instead of public chat."),
     ]
     assert state_store.get_company_password(3) is None
     assert messenger.commands == []


### PR DESCRIPTION
## Summary
- update the default help and password-related messages to describe using the player selection for private whispers
- refresh the README and tests to reflect the new guidance

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbdac53f6c8321b9a1f14d7f2aac84