### PR TITLE
Reorder multilingual messages by language

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Ein Python-Bot, der über den Admin-Port eines OpenTTD-Servers läuft und dabei 
 | `STARTUP_REAPPLY_DELAY_SECONDS` | Verzögerung, bevor gespeicherte Passwörter nach dem Start neu gesetzt werden | `5`               |
 | `RECONNECT_DELAY_SECONDS`       | Wartezeit nach einem Fehler, bevor ein Reconnect versucht wird               | `5`               |
 
-Die Datei `messages.json` kann nach eigenen Wünschen angepasst werden (Texte, Sprache, zusätzliche Hinweise). Platzhalter wie `{client_name}`, `{bot_name}` oder `{company_name}` werden automatisch ersetzt.
+Die Datei `messages.json` kann nach eigenen Wünschen angepasst werden (Texte, Sprache, zusätzliche Hinweise). Platzhalter wie `{client_name}`, `{bot_name}` oder `{company_name}` werden automatisch ersetzt. Die Nachrichten werden unverändert in den Chat weitergegeben; besondere Formatierungen wie Farb-Codes müssen daher direkt im Text hinterlegt werden und hängen von den Möglichkeiten des OpenTTD-Chats ab.
 
 ## OpenTTD-Serverkonfiguration
 
@@ -218,7 +218,8 @@ Veröffentlicht unter der MIT-Lizenz (siehe `LICENSE`).
 
 
 You can adapt `messages.json` to your needs. Placeholders such as `{client_name}`, `{bot_name}` or `{company_name}` are
-replaced automatically.
+replaced automatically. Messages are forwarded to the server unchanged; if you want to experiment with colour control codes you
+need to embed them directly in the text and rely on what the OpenTTD chat supports.
 
 ### OpenTTD server configuration
 

--- a/messages.json
+++ b/messages.json
@@ -1,80 +1,80 @@
 {
   "welcome": [
-    "[DE] Willkommen {client_name}!",
     "[EN] Welcome {client_name}!",
-    "[DE] Dieser Server wird von {bot_name} betreut.",
-    "[EN] This server is maintained by {bot_name}."
+    "[EN] This server is maintained by {bot_name}.",
+    "[DE] Willkommen {client_name}!",
+    "[DE] Dieser Server wird von {bot_name} betreut."
   ],
   "help": [
-    "[DE] Verfügbare Befehle: !help, !rules, !pw <passwort>, !reset, !confirm.",
     "[EN] Available commands: !help, !rules, !pw <password>, !reset, !confirm.",
-    "[DE] Öffne die Spielerauswahl (Spieler-Button oder Strg+P), wähle {bot_name} und nutze die Flüstern-Funktion, um !pw <passwort> privat zu senden.",
-    "[EN] Open the player selection (Players button or Ctrl+P), select {bot_name} and use the whisper function to send !pw <password> privately."
+    "[EN] Open the player selection (Players button or Ctrl+P), select {bot_name} and use the whisper function to send !pw <password> privately.",
+    "[DE] Verfügbare Befehle: !help, !rules, !pw <passwort>, !reset, !confirm.",
+    "[DE] Öffne die Spielerauswahl (Spieler-Button oder Strg+P), wähle {bot_name} und nutze die Flüstern-Funktion, um !pw <passwort> privat zu senden."
   ],
   "rules": [
-    "[DE] 1. Respektiere andere Spieler.",
     "[EN] 1. Respect other players.",
-    "[DE] 2. Blockiere keine Strecken.",
-    "[EN] 2. Do not block tracks."
+    "[EN] 2. Do not block tracks.",
+    "[DE] 1. Respektiere andere Spieler.",
+    "[DE] 2. Blockiere keine Strecken."
   ],
   "password_instructions": [
-    "[DE] Flüstere {bot_name} über die Spielerauswahl (Spieler-Button oder Strg+P) mit !pw <passwort>, um deine Firma zu schützen.",
     "[EN] Whisper {bot_name} via the player selection (Players button or Ctrl+P) using !pw <password> to protect your company.",
-    "[DE] Nach Serverneustarts setzt der Bot das gespeicherte Passwort automatisch wieder.",
-    "[EN] The bot will automatically restore the saved password after server restarts."
+    "[EN] The bot will automatically restore the saved password after server restarts.",
+    "[DE] Flüstere {bot_name} über die Spielerauswahl (Spieler-Button oder Strg+P) mit !pw <passwort>, um deine Firma zu schützen.",
+    "[DE] Nach Serverneustarts setzt der Bot das gespeicherte Passwort automatisch wieder."
   ],
   "password_whisper_only": [
-    "[DE] Bitte nutze die Spielerauswahl, wähle {bot_name} und sende dort !pw <passwort>, nicht im öffentlichen Chat.",
-    "[EN] Please use the player selection, pick {bot_name} and send !pw <password> there instead of public chat."
+    "[EN] Please use the player selection, pick {bot_name} and send !pw <password> there instead of public chat.",
+    "[DE] Bitte nutze die Spielerauswahl, wähle {bot_name} und sende dort !pw <passwort>, nicht im öffentlichen Chat."
   ],
   "password_missing_argument": [
-    "[DE] Bitte gib ein Passwort an: !pw <passwort> oder !pw clear.",
-    "[EN] Please provide a password: !pw <password> or !pw clear."
+    "[EN] Please provide a password: !pw <password> or !pw clear.",
+    "[DE] Bitte gib ein Passwort an: !pw <passwort> oder !pw clear."
   ],
   "password_invalid": [
-    "[DE] Ungültiges Passwort.",
-    "[EN] Invalid password."
+    "[EN] Invalid password.",
+    "[DE] Ungültiges Passwort."
   ],
   "password_set_success": [
-    "[DE] Passwort für Firma {company_name} wurde gespeichert.",
-    "[EN] Password for company {company_name} has been saved."
+    "[EN] Password for company {company_name} has been saved.",
+    "[DE] Passwort für Firma {company_name} wurde gespeichert."
   ],
   "password_clear_success": [
-    "[DE] Passwort für Firma {company_name} wurde entfernt.",
-    "[EN] Password for company {company_name} has been removed."
+    "[EN] Password for company {company_name} has been removed.",
+    "[DE] Passwort für Firma {company_name} wurde entfernt."
   ],
   "password_not_in_company": [
-    "[DE] Du musst einer Firma angehören, um ein Passwort zu setzen.",
-    "[EN] You need to be part of a company to set a password."
+    "[EN] You need to be part of a company to set a password.",
+    "[DE] Du musst einer Firma angehören, um ein Passwort zu setzen."
   ],
   "reset_not_in_company": [
-    "[DE] Du befindest dich aktuell in keiner Firma.",
-    "[EN] You are currently not in a company."
+    "[EN] You are currently not in a company.",
+    "[DE] Du befindest dich aktuell in keiner Firma."
   ],
   "reset_prompt": [
-    "[DE] Du möchtest Firma {company_name} zurücksetzen.",
     "[EN] You want to reset company {company_name}.",
-    "[DE] Verlasse zuerst die Firma (z. B. Zuschauer) und sende dann !confirm.",
-    "[EN] Leave the company first (e.g. become a spectator) and then send !confirm."
+    "[EN] Leave the company first (e.g. become a spectator) and then send !confirm.",
+    "[DE] Du möchtest Firma {company_name} zurücksetzen.",
+    "[DE] Verlasse zuerst die Firma (z. B. Zuschauer) und sende dann !confirm."
   ],
   "reset_confirmed": [
-    "[DE] Firma {company_name} wurde zurückgesetzt.",
-    "[EN] Company {company_name} has been reset."
+    "[EN] Company {company_name} has been reset.",
+    "[DE] Firma {company_name} wurde zurückgesetzt."
   ],
   "reset_no_pending": [
-    "[DE] Es liegt keine offene Zurücksetzung vor.",
-    "[EN] There is no pending reset."
+    "[EN] There is no pending reset.",
+    "[DE] Es liegt keine offene Zurücksetzung vor."
   ],
   "reset_wrong_company": [
-    "[DE] Deine Reset-Anfrage bezog sich auf Firma {company_name}. Bitte sende !reset erneut in der gewünschten Firma.",
-    "[EN] Your reset request was for company {company_name}. Please use !reset again in the company you want to reset."
+    "[EN] Your reset request was for company {company_name}. Please use !reset again in the company you want to reset.",
+    "[DE] Deine Reset-Anfrage bezog sich auf Firma {company_name}. Bitte sende !reset erneut in der gewünschten Firma."
   ],
   "reset_still_in_company": [
-    "[DE] Du befindest dich noch in Firma {company_name}. Verlasse sie zuerst und sende dann !confirm.",
-    "[EN] You are still in company {company_name}. Leave it first and then send !confirm."
+    "[EN] You are still in company {company_name}. Leave it first and then send !confirm.",
+    "[DE] Du befindest dich noch in Firma {company_name}. Verlasse sie zuerst und sende dann !confirm."
   ],
   "company_password_reapplied": [
-    "[DE] Das gespeicherte Passwort für Firma {company_name} wurde erneut gesetzt.",
-    "[EN] The stored password for company {company_name} has been applied again."
+    "[EN] The stored password for company {company_name} has been applied again.",
+    "[DE] Das gespeicherte Passwort für Firma {company_name} wurde erneut gesetzt."
   ]
 }

--- a/src/openttd_bot/messages.py
+++ b/src/openttd_bot/messages.py
@@ -14,82 +14,82 @@ LOGGER = logging.getLogger(__name__)
 
 DEFAULT_MESSAGES: dict[str, Any] = {
     "welcome": [
-        "[DE] Willkommen {client_name}!",
         "[EN] Welcome {client_name}!",
-        "[DE] Dieser Server wird von {bot_name} betreut.",
         "[EN] This server is maintained by {bot_name}.",
+        "[DE] Willkommen {client_name}!",
+        "[DE] Dieser Server wird von {bot_name} betreut.",
     ],
     "help": [
-        "[DE] Verfügbare Befehle: !help, !rules, !pw <passwort>, !reset, !confirm.",
         "[EN] Available commands: !help, !rules, !pw <password>, !reset, !confirm.",
-        "[DE] Öffne die Spielerauswahl (Spieler-Button oder Strg+P), wähle {bot_name} und nutze die Flüstern-Funktion, um !pw <passwort> privat zu senden.",
         "[EN] Open the player selection (Players button or Ctrl+P), select {bot_name} and use the whisper function to send !pw <password> privately.",
+        "[DE] Verfügbare Befehle: !help, !rules, !pw <passwort>, !reset, !confirm.",
+        "[DE] Öffne die Spielerauswahl (Spieler-Button oder Strg+P), wähle {bot_name} und nutze die Flüstern-Funktion, um !pw <passwort> privat zu senden.",
     ],
     "rules": [
-        "[DE] 1. Respektiere andere Spieler.",
         "[EN] 1. Respect other players.",
-        "[DE] 2. Blockiere keine Strecken.",
         "[EN] 2. Do not block tracks.",
+        "[DE] 1. Respektiere andere Spieler.",
+        "[DE] 2. Blockiere keine Strecken.",
     ],
     "password_instructions": [
-        "[DE] Flüstere {bot_name} über die Spielerauswahl (Spieler-Button oder Strg+P) mit !pw <passwort>, um deine Firma zu schützen.",
         "[EN] Whisper {bot_name} via the player selection (Players button or Ctrl+P) using !pw <password> to protect your company.",
-        "[DE] Nach Serverneustarts setzt der Bot das gespeicherte Passwort automatisch wieder.",
         "[EN] The bot will automatically restore the saved password after server restarts.",
+        "[DE] Flüstere {bot_name} über die Spielerauswahl (Spieler-Button oder Strg+P) mit !pw <passwort>, um deine Firma zu schützen.",
+        "[DE] Nach Serverneustarts setzt der Bot das gespeicherte Passwort automatisch wieder.",
     ],
     "password_whisper_only": [
-        "[DE] Bitte nutze die Spielerauswahl, wähle {bot_name} und sende dort !pw <passwort>, nicht im öffentlichen Chat.",
         "[EN] Please use the player selection, pick {bot_name} and send !pw <password> there instead of public chat.",
+        "[DE] Bitte nutze die Spielerauswahl, wähle {bot_name} und sende dort !pw <passwort>, nicht im öffentlichen Chat.",
     ],
     "password_missing_argument": [
-        "[DE] Bitte gib ein Passwort an: !pw <passwort> oder !pw clear.",
         "[EN] Please provide a password: !pw <password> or !pw clear.",
+        "[DE] Bitte gib ein Passwort an: !pw <passwort> oder !pw clear.",
     ],
     "password_invalid": [
-        "[DE] Ungültiges Passwort.",
         "[EN] Invalid password.",
+        "[DE] Ungültiges Passwort.",
     ],
     "password_set_success": [
-        "[DE] Passwort für Firma {company_name} wurde gespeichert.",
         "[EN] Password for company {company_name} has been saved.",
+        "[DE] Passwort für Firma {company_name} wurde gespeichert.",
     ],
     "password_clear_success": [
-        "[DE] Passwort für Firma {company_name} wurde entfernt.",
         "[EN] Password for company {company_name} has been removed.",
+        "[DE] Passwort für Firma {company_name} wurde entfernt.",
     ],
     "password_not_in_company": [
-        "[DE] Du musst einer Firma angehören, um ein Passwort zu setzen.",
         "[EN] You need to be part of a company to set a password.",
+        "[DE] Du musst einer Firma angehören, um ein Passwort zu setzen.",
     ],
     "reset_not_in_company": [
-        "[DE] Du befindest dich aktuell in keiner Firma.",
         "[EN] You are currently not in a company.",
+        "[DE] Du befindest dich aktuell in keiner Firma.",
     ],
     "reset_prompt": [
-        "[DE] Du möchtest Firma {company_name} zurücksetzen.",
         "[EN] You want to reset company {company_name}.",
-        "[DE] Verlasse zuerst die Firma (z. B. Zuschauer) und sende dann !confirm.",
         "[EN] Leave the company first (e.g. become a spectator) and then send !confirm.",
+        "[DE] Du möchtest Firma {company_name} zurücksetzen.",
+        "[DE] Verlasse zuerst die Firma (z. B. Zuschauer) und sende dann !confirm.",
     ],
     "reset_confirmed": [
-        "[DE] Firma {company_name} wurde zurückgesetzt.",
         "[EN] Company {company_name} has been reset.",
+        "[DE] Firma {company_name} wurde zurückgesetzt.",
     ],
     "reset_no_pending": [
-        "[DE] Es liegt keine offene Zurücksetzung vor.",
         "[EN] There is no pending reset.",
+        "[DE] Es liegt keine offene Zurücksetzung vor.",
     ],
     "reset_wrong_company": [
-        "[DE] Deine Reset-Anfrage bezog sich auf Firma {company_name}. Bitte sende !reset erneut in der gewünschten Firma.",
         "[EN] Your reset request was for company {company_name}. Please use !reset again in the company you want to reset.",
+        "[DE] Deine Reset-Anfrage bezog sich auf Firma {company_name}. Bitte sende !reset erneut in der gewünschten Firma.",
     ],
     "reset_still_in_company": [
-        "[DE] Du befindest dich noch in Firma {company_name}. Verlasse sie zuerst und sende dann !confirm.",
         "[EN] You are still in company {company_name}. Leave it first and then send !confirm.",
+        "[DE] Du befindest dich noch in Firma {company_name}. Verlasse sie zuerst und sende dann !confirm.",
     ],
     "company_password_reapplied": [
-        "[DE] Das gespeicherte Passwort für Firma {company_name} wurde erneut gesetzt.",
         "[EN] The stored password for company {company_name} has been applied again.",
+        "[DE] Das gespeicherte Passwort für Firma {company_name} wurde erneut gesetzt.",
     ],
 }
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -84,18 +84,18 @@ def test_join_sends_welcome_help_and_rules(bot):
     core.on_welcome(SimpleNamespace(server_name="TestServer"))
     core.on_client_info(SimpleNamespace(id=1, name="Alice", company_id=SPECTATOR_COMPANY_ID))
     assert messenger.private_messages[:12] == [
-        (1, "[DE] Willkommen Alice!"),
         (1, "[EN] Welcome Alice!"),
-        (1, "[DE] Dieser Server wird von ServerBot betreut."),
         (1, "[EN] This server is maintained by ServerBot."),
-        (1, "[DE] Verfügbare Befehle: !help, !rules, !pw <passwort>, !reset, !confirm."),
+        (1, "[DE] Willkommen Alice!"),
+        (1, "[DE] Dieser Server wird von ServerBot betreut."),
         (1, "[EN] Available commands: !help, !rules, !pw <password>, !reset, !confirm."),
-        (1, "[DE] Öffne die Spielerauswahl (Spieler-Button oder Strg+P), wähle ServerBot und nutze die Flüstern-Funktion, um !pw <passwort> privat zu senden."),
         (1, "[EN] Open the player selection (Players button or Ctrl+P), select ServerBot and use the whisper function to send !pw <password> privately."),
-        (1, "[DE] 1. Respektiere andere Spieler."),
+        (1, "[DE] Verfügbare Befehle: !help, !rules, !pw <passwort>, !reset, !confirm."),
+        (1, "[DE] Öffne die Spielerauswahl (Spieler-Button oder Strg+P), wähle ServerBot und nutze die Flüstern-Funktion, um !pw <passwort> privat zu senden."),
         (1, "[EN] 1. Respect other players."),
-        (1, "[DE] 2. Blockiere keine Strecken."),
         (1, "[EN] 2. Do not block tracks."),
+        (1, "[DE] 1. Respektiere andere Spieler."),
+        (1, "[DE] 2. Blockiere keine Strecken."),
     ]
 
 
@@ -105,10 +105,10 @@ def test_help_command_sends_help(bot):
     messenger.reset_messages()
     core.on_chat(make_chat(1, "!help"))
     assert messenger.private_messages == [
-        (1, "[DE] Verfügbare Befehle: !help, !rules, !pw <passwort>, !reset, !confirm."),
         (1, "[EN] Available commands: !help, !rules, !pw <password>, !reset, !confirm."),
-        (1, "[DE] Öffne die Spielerauswahl (Spieler-Button oder Strg+P), wähle ServerBot und nutze die Flüstern-Funktion, um !pw <passwort> privat zu senden."),
         (1, "[EN] Open the player selection (Players button or Ctrl+P), select ServerBot and use the whisper function to send !pw <password> privately."),
+        (1, "[DE] Verfügbare Befehle: !help, !rules, !pw <passwort>, !reset, !confirm."),
+        (1, "[DE] Öffne die Spielerauswahl (Spieler-Button oder Strg+P), wähle ServerBot und nutze die Flüstern-Funktion, um !pw <passwort> privat zu senden."),
     ]
 
 
@@ -119,8 +119,8 @@ def test_password_requires_private(bot):
     messenger.reset_messages()
     core.on_chat(make_chat(5, "!pw geheim", ChatDestTypes.BROADCAST))
     assert messenger.private_messages == [
-        (5, "[DE] Bitte nutze die Spielerauswahl, wähle ServerBot und sende dort !pw <passwort>, nicht im öffentlichen Chat."),
         (5, "[EN] Please use the player selection, pick ServerBot and send !pw <password> there instead of public chat."),
+        (5, "[DE] Bitte nutze die Spielerauswahl, wähle ServerBot und sende dort !pw <passwort>, nicht im öffentlichen Chat."),
     ]
     assert state_store.get_company_password(3) is None
     assert messenger.commands == []
@@ -135,8 +135,8 @@ def test_password_private_sets_and_persists(bot):
     assert state_store.get_company_password(2) == "geheim"
     assert ("set_pw", 2, "geheim") in messenger.commands
     assert messenger.private_messages[-2:] == [
-        (7, "[DE] Passwort für Firma Firma 2 wurde gespeichert."),
         (7, "[EN] Password for company Firma 2 has been saved."),
+        (7, "[DE] Passwort für Firma Firma 2 wurde gespeichert."),
     ]
 
 
@@ -150,8 +150,8 @@ def test_password_clear(bot):
     assert state_store.get_company_password(4) is None
     assert ("clear_pw", 4, None) in messenger.commands
     assert messenger.private_messages[-2:] == [
-        (8, "[DE] Passwort für Firma Firma 4 wurde entfernt."),
         (8, "[EN] Password for company Firma 4 has been removed."),
+        (8, "[DE] Passwort für Firma Firma 4 wurde entfernt."),
     ]
 
 
@@ -162,17 +162,17 @@ def test_reset_and_confirm(bot):
     messenger.reset_messages()
     core.on_chat(make_chat(9, "!reset"))
     assert messenger.private_messages[:4] == [
-        (9, "[DE] Du möchtest Firma Firma 6 zurücksetzen."),
         (9, "[EN] You want to reset company Firma 6."),
-        (9, "[DE] Verlasse zuerst die Firma (z. B. Zuschauer) und sende dann !confirm."),
         (9, "[EN] Leave the company first (e.g. become a spectator) and then send !confirm."),
+        (9, "[DE] Du möchtest Firma Firma 6 zurücksetzen."),
+        (9, "[DE] Verlasse zuerst die Firma (z. B. Zuschauer) und sende dann !confirm."),
     ]
     core.on_client_update(SimpleNamespace(id=9, name="Eve", company_id=SPECTATOR_COMPANY_ID))
     core.on_chat(make_chat(9, "!confirm"))
     assert ("reset", 6, None) in messenger.commands
     assert messenger.private_messages[-2:] == [
-        (9, "[DE] Firma Firma 6 wurde zurückgesetzt."),
         (9, "[EN] Company Firma 6 has been reset."),
+        (9, "[DE] Firma Firma 6 wurde zurückgesetzt."),
     ]
 
 
@@ -184,8 +184,8 @@ def test_reset_confirm_requires_leaving_company(bot):
     core.on_chat(make_chat(11, "!reset"))
     core.on_chat(make_chat(11, "!confirm"))
     assert messenger.private_messages[-2:] == [
-        (11, "[DE] Du befindest dich noch in Firma Firma 10. Verlasse sie zuerst und sende dann !confirm."),
         (11, "[EN] You are still in company Firma 10. Leave it first and then send !confirm."),
+        (11, "[DE] Du befindest dich noch in Firma Firma 10. Verlasse sie zuerst und sende dann !confirm."),
     ]
     assert not any(cmd for cmd in messenger.commands if cmd[0] == "reset")
 
@@ -202,11 +202,11 @@ def test_reset_confirm_cancelled_in_other_company(bot):
     assert messenger.private_messages[-2:] == [
         (
             12,
-            "[DE] Deine Reset-Anfrage bezog sich auf Firma Firma 20. Bitte sende !reset erneut in der gewünschten Firma.",
+            "[EN] Your reset request was for company Firma 20. Please use !reset again in the company you want to reset.",
         ),
         (
             12,
-            "[EN] Your reset request was for company Firma 20. Please use !reset again in the company you want to reset.",
+            "[DE] Deine Reset-Anfrage bezog sich auf Firma Firma 20. Bitte sende !reset erneut in der gewünschten Firma.",
         ),
     ]
     assert not any(cmd for cmd in messenger.commands if cmd[0] == "reset")
@@ -220,8 +220,8 @@ def test_reapply_password_on_company_info(bot):
     core.on_company_info(SimpleNamespace(id=12, name="Firma 12", manager_name="", passworded=False))
     assert ("set_pw", 12, "schutz") in messenger.commands
     assert messenger.private_messages[-2:] == [
-        (13, "[DE] Das gespeicherte Passwort für Firma Firma 12 wurde erneut gesetzt."),
         (13, "[EN] The stored password for company Firma 12 has been applied again."),
+        (13, "[DE] Das gespeicherte Passwort für Firma Firma 12 wurde erneut gesetzt."),
     ]
 
 


### PR DESCRIPTION
## Summary
- sort all multiline message templates so English variants are sent before the German ones
- update default test expectations to reflect the new ordering
- document in the README that colour formatting has to be embedded directly in the configured texts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbf938068883218d4d45818084b818