### PR TITLE
Add admin new game command

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -76,5 +76,17 @@
   "company_password_reapplied": [
     "[EN] The stored password for company {company_name} has been applied again.",
     "[DE] Das gespeicherte Passwort für Firma {company_name} wurde erneut gesetzt."
+  ],
+  "newgame_missing_password": [
+    "[EN] Please provide the admin password: !newgame <password>.",
+    "[DE] Bitte gib das Admin-Passwort an: !newgame <passwort>."
+  ],
+  "newgame_invalid_password": [
+    "[EN] Invalid admin password.",
+    "[DE] Ungültiges Admin-Passwort."
+  ],
+  "newgame_started": [
+    "[EN] Clearing all company passwords and starting a new game.",
+    "[DE] Alle Firmenpasswörter werden gelöscht und ein neues Spiel wird gestartet."
   ]
 }

--- a/openttd_bot/messages.py
+++ b/openttd_bot/messages.py
@@ -91,6 +91,18 @@ DEFAULT_MESSAGES: dict[str, Any] = {
         "[EN] The stored password for company {company_name} has been applied again.",
         "[DE] Das gespeicherte Passwort für Firma {company_name} wurde erneut gesetzt.",
     ],
+    "newgame_missing_password": [
+        "[EN] Please provide the admin password: !newgame <password>.",
+        "[DE] Bitte gib das Admin-Passwort an: !newgame <passwort>.",
+    ],
+    "newgame_invalid_password": [
+        "[EN] Invalid admin password.",
+        "[DE] Ungültiges Admin-Passwort.",
+    ],
+    "newgame_started": [
+        "[EN] Clearing all company passwords and starting a new game.",
+        "[DE] Alle Firmenpasswörter werden gelöscht und ein neues Spiel wird gestartet.",
+    ],
 }
 
 

--- a/openttd_bot/messenger.py
+++ b/openttd_bot/messenger.py
@@ -72,6 +72,12 @@ class AdminMessenger:
         LOGGER.info("Resetting company %s (RCON id %s)", company_id + 1, company_number)
         self._admin.send_rcon(f"reset_company {company_number}")
 
+    def restart_game(self) -> None:
+        """Start a fresh game on the server."""
+
+        LOGGER.info("Requesting new game via RCON")
+        self._admin.send_rcon("restart")
+
     @staticmethod
     def _format_company_password_command(company_id: int, password: str) -> str:
         escaped = password.replace("\\", "\\\\").replace('"', '\\"')

--- a/openttd_bot/state.py
+++ b/openttd_bot/state.py
@@ -73,6 +73,15 @@ class StateStore:
                 del self._state.companies[str(company_id)]
                 self._write()
 
+    def clear_all_company_passwords(self) -> None:
+        """Remove all stored company passwords."""
+
+        with self._lock:
+            if not self._state.companies:
+                return
+            self._state.companies.clear()
+            self._write()
+
     def iter_company_passwords(self) -> Iterator[tuple[int, str]]:
         """Yield all stored company passwords."""
 

--- a/tests/test_messenger.py
+++ b/tests/test_messenger.py
@@ -18,9 +18,11 @@ def test_rcon_commands_use_one_based_company_ids() -> None:
     messenger.set_company_password(5, "secret")
     messenger.clear_company_password(5)
     messenger.reset_company(5)
+    messenger.restart_game()
 
     assert admin.rcon_commands == [
         'company_pw 6 "secret"',
         'company_pw 6 ""',
         'reset_company 6',
+        'restart',
     ]


### PR DESCRIPTION
## Summary
- add a `!newgame` admin command that clears passwords and restarts the server when given the admin password
- extend state handling and messenger helpers to remove stored passwords and trigger a new game
- cover the new behaviour with default messages and automated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccf6a569f083218596a60b32e69ab0