### PR TITLE
Fix join message formatting

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -91,8 +91,15 @@ def test_merge_sections_combines_language_blocks():
 
     merged = catalog.merge_sections(lines)
 
-    assert len(merged) == 2
-    eng_block, de_block = merged
+    assert merged.count("---------------------[ENG]---------------------") == 1
+    assert merged.count("---------------------[DE]---------------------") == 1
+
+    eng_index = merged.index("---------------------[ENG]---------------------")
+    de_index = merged.index("---------------------[DE]---------------------")
+    assert eng_index < de_index
+
+    eng_block = " ".join(merged[eng_index + 1 : de_index])
+    de_block = " ".join(merged[de_index + 1 :])
     assert "Welcome Alice!" in eng_block
     assert "Available commands" in eng_block
     assert "Willkommen Alice!" in de_block


### PR DESCRIPTION
## Summary
- collapse repeated language section headers when merging message templates so each language banner only appears once
- return individual lines instead of newline-joined blocks to keep chat output readable
- adjust tests to reflect the new formatting behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd1d5eaaa48321b4d9b8de275605d0