### PR TITLE
Handle connection refused with clearer log message

### DIFF
--- a/openttd_bot/runner.py
+++ b/openttd_bot/runner.py
@@ -158,6 +158,14 @@ class BotRunner:
             except KeyboardInterrupt:  # pragma: no cover - handled by runner
                 LOGGER.info("Interrupted by user")
                 raise
+            except ConnectionRefusedError as exc:
+                LOGGER.error(
+                    "Unable to connect to %s:%s (%s). Is the server online and is the admin port open?",
+                    self.config.host,
+                    self.config.admin_port,
+                    exc,
+                )
+                time.sleep(self.config.reconnect_delay_seconds)
             except Exception as exc:  # pragma: no cover - connection errors
                 LOGGER.exception("Connection error: %s", exc)
                 time.sleep(self.config.reconnect_delay_seconds)


### PR DESCRIPTION
## Summary
- add a dedicated handler for ConnectionRefusedError in the bot runner
- provide a user-friendly log message advising to check server status when the admin port is unreachable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7d79bef508321b591bb3c7881ad58